### PR TITLE
Make remote domain configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ fubitive.vim
 
 Extend [fugitive.vim](https://github.com/tpope/vim-fugitive) to support
 Bitbucket URLs in `:Gbrowse`.
+
+## Configuration
+
+The default domain when searching remotes is `bitbucket.org`. To make this
+plugin work with a Bitbucket instance under a different domain, simply add the
+following to your `.vimrc` (taking care to escape special characters):
+
+```vim
+let g:fubitive_domain_pattern = 'code\.example\.com'
+```

--- a/plugin/fubitive.vim
+++ b/plugin/fubitive.vim
@@ -7,7 +7,7 @@ function! s:bitbucket_url(opts, ...) abort
     return ''
   endif
   let path = substitute(a:opts.path, '^/', '', '')
-  let domain_pattern = 'bitbucket\.org'
+  let domain_pattern = exists('g:fubitive_domain_pattern') ? g:fubitive_domain_pattern : 'bitbucket\.org'
   let domains = exists('g:fugitive_bitbucket_domains') ? g:fugitive_bitbucket_domains : []
   for domain in domains
     let domain_pattern .= '\|' . escape(split(domain, '://')[-1], '.')


### PR DESCRIPTION
This makes the remote domain configurable while still defaulting to `bitbucket.org`. Hopefully we can upstream the changes on this fork one day :)

Thanks for the great work here!